### PR TITLE
feat: add engineering standards (ESLint, Prettier, strict mode, scripts)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,22 @@
+module.exports = {
+  root: true,
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module',
+    project: './tsconfig.json',
+  },
+  plugins: ['@typescript-eslint'],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended-type-checked',
+    'plugin:@typescript-eslint/stylistic-type-checked',
+  ],
+  rules: {
+    '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/explicit-function-return-type': 'off',
+    '@typescript-eslint/explicit-module-boundary-types': 'off',
+    '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
+  },
+  ignorePatterns: ['dist', 'node_modules', 'coverage', '*.js', '*.d.ts'],
+};

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,12 @@
+dist/
+node_modules/
+coverage/
+*.d.ts
+*.d.ts.map
+package-lock.json
+yarn.lock
+pnpm-lock.yaml
+.env
+.env.*
+*.log
+cache/

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,10 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "printWidth": 100,
+  "tabWidth": 2,
+  "useTabs": false,
+  "arrowParens": "always",
+  "endOfLine": "lf"
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ai-valuation-skill",
   "version": "0.1.0",
-  "description": "AI 项目身价计算器 - 基于 PoC/Alpha/Beta/GA 四级估值模型",
+  "description": "AI 项目身价计算器 - 基于 PoC/Alpha/Beta/GA 四级估值模型的开源评分系统",
   "keywords": [
     "ai-valuation",
     "startup-valuation",
@@ -14,14 +14,21 @@
     "url": "https://github.com/xiejianjun000/ai-valuation-skill"
   },
   "license": "MIT",
-  "main": "src/scoring.js",
+  "main": "dist/scoring.js",
+  "types": "dist/scoring.d.ts",
   "bin": {
     "ai-valuation": "./bin/ai-valuation"
   },
   "scripts": {
     "build": "tsc",
+    "dev": "tsc --watch",
     "start": "node bin/ai-valuation help",
-    "test": "npm run build && node examples/basic-score.js"
+    "lint": "eslint . --ext .ts",
+    "lint:fix": "eslint . --ext .ts --fix",
+    "test": "npm run build && node examples/basic-score.js",
+    "type-check": "tsc --noEmit",
+    "format": "prettier --write \"**/*.{ts,js,json,md}\"",
+    "format:check": "prettier --check \"**/*.{ts,js,json,md}\""
   },
   "files": [
     "dist/",
@@ -29,8 +36,11 @@
     "examples/",
     "docs/"
   ],
-  "types": "dist/scoring.d.ts",
   "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^8.0.0",
+    "@typescript-eslint/parser": "^8.0.0",
+    "eslint": "^9.0.0",
+    "prettier": "^3.3.0",
     "typescript": "^6.0.3"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "declaration": true,
-    "strict": false
+    "strict": true,
+    "composite": true
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
## Summary

This PR adds engineering standards compliance to the ai-valuation-skill project:

### Changes Made

1. **ESLint Configuration** - Added `.eslintrc.js` with TypeScript-eslint support
2. **Prettier Configuration** - Added `.prettierrc` and `.prettierignore`
3. **TypeScript Strict Mode** - Changed `tsconfig.json` from `strict: false` to `strict: true`
4. **Complete package.json scripts**:
   - `build`: Compile TypeScript
   - `dev`: Watch mode
   - `lint`: Run ESLint
   - `lint:fix`: Auto-fix lint issues
   - `test`: Build and run tests
   - `type-check`: TypeScript type checking
   - `format`: Format code with Prettier
   - `format:check`: Check formatting
5. **tsconfig.json**: Added `composite: true` for project references

### Standards Compliance

- ✅ TypeScript Strict Mode
- ✅ ESLint Configuration
- ✅ Prettier Configuration
- ✅ Build Pipeline (package.json scripts)
- ✅ TypeScript Project References (composite)
- ✅ README + CHANGELOG
- ✅ GitHub Actions CI/CD
- ✅ .gitignore

Please review and merge!