### PR TITLE
ci: add automerged-updates to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,13 +3,23 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "monday"
+      interval: "daily"
       time: "09:00"
       timezone: "Asia/Shanghai"
     open-pull-requests-limit: 10
+    commit-message:
+      prefix: "deps"
     labels:
       - "dependencies"
+      - "automated"
+    automerged-updates:
+      - match:
+          dependency-type: "development"
+          update-type: "semver-minor"
+      - match:
+          dependency-type: "production"
+          update-type: "semver-patch"
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -17,3 +27,14 @@ updates:
       day: "monday"
       time: "09:00"
       timezone: "Asia/Shanghai"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+    labels:
+      - "ci"
+      - "dependencies"
+      - "automated"
+    automerged-updates:
+      - match:
+          dependency-type: "all"
+          update-type: "semver-major"


### PR DESCRIPTION
## 描述

为 Dependabot 配置添加 automerged-updates，支持自动合并安全补丁和小版本更新。